### PR TITLE
Corrected implementation of useful() 

### DIFF
--- a/contrib/adsabs/src/java/org/apache/lucene/queryparser/flexible/aqp/builders/AqpAdsabsSubQueryProvider.java
+++ b/contrib/adsabs/src/java/org/apache/lucene/queryparser/flexible/aqp/builders/AqpAdsabsSubQueryProvider.java
@@ -716,7 +716,9 @@ AqpFunctionQueryBuilderProvider {
 				Query innerQuery = fp.parseNestedQuery();
 				
 				@SuppressWarnings("unchecked")
-        SolrCacheWrapper<CitationLRUCache<Object, Integer>> referencesWrapper = new SolrCacheWrapper.ReferencesCache(
+				SolrCacheWrapper<CitationLRUCache<Object, Integer>> referencesWrapper = new SolrCacheWrapper.ReferencesCache(
+						(CitationLRUCache<Object, Integer>) fp.getReq().getSearcher().getCache("citations-cache"));
+				SolrCacheWrapper<CitationLRUCache<Object, Integer>> citationsWrapper = new SolrCacheWrapper.CitationsCache(
 						(CitationLRUCache<Object, Integer>) fp.getReq().getSearcher().getCache("citations-cache"));
 				
 				LuceneCacheWrapper<float[]> boostWrapper = LuceneCacheWrapper.getFloatCache("cite_read_boost", 
@@ -725,7 +727,7 @@ AqpFunctionQueryBuilderProvider {
 				return  new SecondOrderQuery( // references
 						new SecondOrderQuery( // topn
 								new SecondOrderQuery(innerQuery, // classic_relevance
-										new SecondOrderCollectorAdsClassicScoringFormula(referencesWrapper, boostWrapper)), 
+										new SecondOrderCollectorAdsClassicScoringFormula(citationsWrapper, boostWrapper)), 
 										new SecondOrderCollectorTopN(200)),
 										new SecondOrderCollectorCitesRAM(referencesWrapper));
 


### PR DESCRIPTION
by having it use the proper classic_relevance inner function
