### PR TITLE
schema update for aff, publisher and version

### DIFF
--- a/contrib/adsabs/src/java/org/apache/lucene/search/similarities/BM25SimilarityADS.java
+++ b/contrib/adsabs/src/java/org/apache/lucene/search/similarities/BM25SimilarityADS.java
@@ -265,7 +265,7 @@ public class BM25SimilarityADS extends Similarity {
     /** precomputed norm[256] with k1 * ((1 - b) + b * dl / avgdl) */
     private final float cache[];
 
-    BM25Stats(String field, Explanation idf, float avgdl, float cache[]) {
+    BM25StatsADS(String field, Explanation idf, float avgdl, float cache[]) {
       this.field = field;
       this.idf = idf;
       this.avgdl = avgdl;
@@ -287,7 +287,7 @@ public class BM25SimilarityADS extends Similarity {
     } 
   }
 
-  private Explanation explainTFNorm(int doc, Explanation freq, BM25Stats stats, NumericDocValues norms) {
+  private Explanation explainTFNorm(int doc, Explanation freq, BM25StatsADS stats, NumericDocValues norms) {
     List<Explanation> subs = new ArrayList<>();
     subs.add(freq);
     subs.add(Explanation.match(k1, "parameter k1"));
@@ -307,7 +307,7 @@ public class BM25SimilarityADS extends Similarity {
     }
   }
 
-  private Explanation explainScore(int doc, Explanation freq, BM25Stats stats, NumericDocValues norms) {
+  private Explanation explainScore(int doc, Explanation freq, BM25StatsADS stats, NumericDocValues norms) {
     Explanation boostExpl = Explanation.match(stats.boost, "boost");
     List<Explanation> subs = new ArrayList<>();
     if (boostExpl.getValue() != 1.0f)

--- a/contrib/adsabs/src/test/org/adsabs/TestAdsAllFields.java
+++ b/contrib/adsabs/src/test/org/adsabs/TestAdsAllFields.java
@@ -124,12 +124,12 @@ public class TestAdsAllFields extends MontySolrQueryTestCase {
 
 			  ", \"abstract\": \"all no-sky survey q'i quotient\"" +
 			  ", \"aff\": [\"-\", \"NASA Kavli space center, Cambridge, MA 02138, USA\", \"Einstein institute, Zurych, Switzerland\"]" +
-			  ", \"aff_abbrev\": [\"-\", \"NASA Kavli\", \"Einstein institute\"]" +
-			  ", \"aff_canonical\": [\"-\", \"NASA Kavli\", \"Einstein institute\"]" +
-			  ", \"aff_facet\": [\"-\", \"NASA Kavli\", \"Einstein institute\"]" +	
-			  ", \"aff_facet_heir\": [\"0/-\", \"1/NASA Kavli\", \"2/Einstein institute\", \"1/CfA\"]" +
-			  ", \"aff_id\": [\"-\", \"A123;45678\", \"A545\"]" +
-			  ", \"aff_raw\": [\"-\", \"NASA Kavli\", \"Einstein institute\"]" +
+		          ", \"aff_abbrev\": [\"CfA\", \"Harvard U/Dep Ast\", \"-\"]" +
+			  ", \"aff_canonical\": [\"Harvard Smithsonian Center for Astrophysics\", \"Harvard University, Department of Astronomy\", \"-\"]" +
+			  ", \"aff_facet\": [[\"A1234\", \"facet abbrev/parent abbrev\"]]" +
+			  ", \"aff_facet_heir\": [\"1812/61814\", \"8264/61814\", \"1812/A1036\", \"-\"]" +
+			  ", \"aff_id\": [\"61814\", \"A1036\", \"-\"]" +
+			  ", \"aff_raw\": [\"-\", \"Center for Astrophysics, 60 Garden Street, Cambridge MA 02138, USA\", \"Department of Astronomy, Harvard University, 60 Garden St., Cambridge, MA 02130, USA\"]" +
 			  ", \"alternate_bibcode\": [\"2014JNuM..455...1a1\", \"2014JNuM..455...1a2\"]" +
 			  ", \"alternate_title\": \"This is of the alternate\"" +
 

--- a/contrib/adsabs/src/test/org/adsabs/TestAdsAllFields.java
+++ b/contrib/adsabs/src/test/org/adsabs/TestAdsAllFields.java
@@ -124,6 +124,12 @@ public class TestAdsAllFields extends MontySolrQueryTestCase {
 
 			  ", \"abstract\": \"all no-sky survey q'i quotient\"" +
 			  ", \"aff\": [\"-\", \"NASA Kavli space center, Cambridge, MA 02138, USA\", \"Einstein institute, Zurych, Switzerland\"]" +
+			  ", \"aff_abbrev\": [\"-\", \"NASA Kavli\", \"Einstein institute\"]" +
+			  ", \"aff_canonical\": [\"-\", \"NASA Kavli\", \"Einstein institute\"]" +
+			  ", \"aff_facet\": [\"-\", \"NASA Kavli\", \"Einstein institute\"]" +	
+			  ", \"aff_facet_heir\": [\"0/-\", \"1/NASA Kavli\", \"2/Einstein institute\", \"1/CfA\"]" +
+			  ", \"aff_id\": [\"-\", \"A123;45678\", \"A545\"]" +
+			  ", \"aff_raw\": [\"-\", \"NASA Kavli\", \"Einstein institute\"]" +
 			  ", \"alternate_bibcode\": [\"2014JNuM..455...1a1\", \"2014JNuM..455...1a2\"]" +
 			  ", \"alternate_title\": \"This is of the alternate\"" +
 
@@ -217,6 +223,7 @@ public class TestAdsAllFields extends MontySolrQueryTestCase {
 				", \"property\": [\"Catalog\", \"Nonarticle\", \"Data\"]" +
 				// must be: "yyyy-MM-dd (metadata often is just: yyyy-MM|yyyy)
 				", \"pubdate\": \"2013-08-05\"" +
+		                ", \"publisher\": \"Academic Press\"" +
 				", \"pubnote\": [\"pubnote1 pubnoteFoo\", \"pubnote2\"]" +
 				", \"read_count\": 50" +
 				", \"reader\": [\"abaesrwersdlfkjsd\", \"asfasdflkjsdfsldj\"]" +
@@ -228,6 +235,7 @@ public class TestAdsAllFields extends MontySolrQueryTestCase {
 				", \"title\": \"This is of the title\"" +
 
 				", \"update_timestamp\": \"2010-03-04T22:01:32.809Z\"" +
+				", \"version\": \"1.2.3\"" +		    
 				", \"volume\": \"l24\"" +
 				", \"year\": \"2013\"" +
 				
@@ -619,6 +627,14 @@ public class TestAdsAllFields extends MontySolrQueryTestCase {
 				"//*[@numFound='1']",
 				"//doc/int[@name='recid'][.='100']");
 
+		/*
+		 * version
+		 */
+		assertQ(req("q", "volume:l.2.3"),
+				"//*[@numFound='1']",
+				"//doc/int[@name='recid'][.='100']");
+		assertQ(req("q", "volume:v24"),
+				"//*[@numFound='0']");
 
 
 		/*
@@ -831,6 +847,15 @@ public class TestAdsAllFields extends MontySolrQueryTestCase {
 		assertQ(req("q", "abstract:\"q'i\"", "fl", "recid,abstract,title"), "//*[@numFound='1']");
 		assertQ(req("q", "abstract:\"q\\\\'i\"", "fl", "recid,abstract,title"), "//*[@numFound='1']");
 
+
+		/*
+		 * publisher
+		 */
+
+		assertQ(req("q", "publisher:Academic Press"),
+        "//*[@numFound='1']",
+        "//doc/int[@name='recid'][.='100']"
+    );
 		
 		/*
 		 * pubnote

--- a/contrib/examples/adsabs/server/solr/collection1/conf/schema.xml
+++ b/contrib/examples/adsabs/server/solr/collection1/conf/schema.xml
@@ -1108,6 +1108,13 @@
       In ADS this field contains a language of the main title. Currently, this value
       is present in a very small portion of records (try searching for lang:*)
 
+    * publisher
+
+      the name of the publisher
+
+    * version
+
+      initially asclepias version, available to be used more widely
 
      -->
 		<field name="pub" type="normalized_text_ascii" indexed="true" stored="true"
@@ -1141,7 +1148,12 @@
 
 		<field name="lang" type="normalized_text_ascii_notokenization" indexed="true" stored="${storeAll:false}"
 			omitNorms="true" omitTermFreqAndPositions="true"/>
+		
+		<field name="publisher" type="normalized_text_ascii" indexed="true" stored="true"
+		  omitNorms="true" />
 
+		<field name="version" type="string" indexed="true" stored="true"
+		  omitNorms="true" />
 
 		<field name="date" type="tdate" indexed="true" stored="true"
 			omitNorms="true" omitTermFreqAndPositions="true"/>
@@ -1193,6 +1205,19 @@
             
 		<field name="aff" type="affiliation_text" indexed="true" stored="true"
 			multiValued="true" omitNorms="true"/>
+		<field name="aff_abbrev" type="affiliation_text" indexed="true" stored="true"
+		       multiValued="true" omitNorms="true"/>
+		<field name="aff_canonical" type="affiliation_text" indexed="true" stored="true"
+			multiValued="true" omitNorms="true"/>
+		<field name="aff_facet" type="string" indexed="true" stored="${storeAll:false}"
+		       multiValued="true" omitNorms="true" omitTermFreqAndPositions="true"/>
+		<field name="aff_facet_hier" type="string" indexed="true" stored="${storeAll:false}"
+		  multiValued="true" omitNorms="true" omitTermFreqAndPositions="true"/>
+		<field name="aff_id" type="affiliation_text" indexed="true" stored="true"
+		       multiValued="true" omitNorms="true"/>
+		<field name="aff_raw" type="normalized_text_ascii" indexed="true" stored="true"
+		  omitNorms="true" />
+
 
 		<field name="email" type="normalized_text_ascii" indexed="true" stored="true"
 			multiValued="true" omitNorms="true"/>
@@ -1889,6 +1914,14 @@
           indexed="true" stored="true" required="false" multiValued="true" omitNorms="true" omitTermFreqAndPositions="true" />
 
 
+	<!--
+	    we define a dynamic field to match anything.
+	    it prevents document rejection on adds when they have one more or fields
+	    not explicitly defined in the schema.  this allows us to more easily
+	    evolve the schema.  This dynamic field should be the last one declared.
+	-->
+	<dynamicField name="*" type="ignored" multiValued="true" />
+	
 	</fields>
 
 	<uniqueKey>id</uniqueKey>

--- a/contrib/examples/adsabs/server/solr/collection1/conf/schema.xml
+++ b/contrib/examples/adsabs/server/solr/collection1/conf/schema.xml
@@ -1913,15 +1913,6 @@
         <field name="esources" type="normalized_string"
           indexed="true" stored="true" required="false" multiValued="true" omitNorms="true" omitTermFreqAndPositions="true" />
 
-
-	<!--
-	    we define a dynamic field to match anything.
-	    it prevents document rejection on adds when they have one more or fields
-	    not explicitly defined in the schema.  this allows us to more easily
-	    evolve the schema.  This dynamic field should be the last one declared.
-	-->
-	<dynamicField name="*" type="ignored" multiValued="true" />
-	
 	</fields>
 
 	<uniqueKey>id</uniqueKey>


### PR DESCRIPTION
added 6 fields for augmented affiliation (canonical, facets, id, etc.)
added version which asclepias will populate
added publisher which bib/import will populate
also fixed syntax error in BM25SimilarityADS
note unit tests were not passing before this change and are still failing

We will need to tweak this PR based on discussions