### PR TITLE
fix typo in python name processing code

### DIFF
--- a/contrib/adsabs/src/jython/jython_name_parser.py
+++ b/contrib/adsabs/src/jython/jython_name_parser.py
@@ -48,6 +48,6 @@ class HumanParser(JythonNameParser):
                 start = input.find("' ")
                 end = start + 2
                 while end+1 < len(input) and input[end+1] == ' ':
-                    end =+ 1 
+                    end += 1 
                 input = input.replace(input[start:end], "'")
         return input

--- a/contrib/adsabs/src/test/org/jython/monty/TestJythonNameParser.java
+++ b/contrib/adsabs/src/test/org/jython/monty/TestJythonNameParser.java
@@ -53,6 +53,10 @@ public class TestJythonNameParser extends LuceneTestCase {
         //System.out.println(i);
       }
     }
+
+    res = instance.parse_human_name("Stephen M'   Donald");
+    assertEquals(res.get("First"), "Stephen");
+    assertEquals(res.get("Last"), "M'Donald");
     
   }
   


### PR DESCRIPTION
processes of certain names with a ' could cause the query thread to enter an infinite loop.  it required multiple spaces after the ' character

Also discussed in a google doc at https://docs.google.com/document/d/14QJkF2LYMBT1vg4HX_rOXQ33cEM6Cwqrj9RljFuXYMs/edit#heading=h.5zlrzf6d5gjj